### PR TITLE
Migrate to Federalist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
-gem 'go_script'
+gem 'jekyll', '~> 3.1.0'
 
 group :jekyll_plugins do
-  gem 'guides_style_18f'
+  gem 'guides_style_18f', :git => 'https://github.com/18F/guides-style.git', :branch => 'pages-migration-updates'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gem 'jekyll', '~> 3.1.0'
 
 group :jekyll_plugins do
-  gem 'guides_style_18f', :git => 'https://github.com/18F/guides-style.git', :branch => 'pages-migration-updates'
+  gem 'guides_style_18f'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,14 @@
-GIT
-  remote: https://github.com/18F/guides-style.git
-  revision: a3a350d3a73f964b11f9b87803ab7ff77087ee87
-  branch: pages-migration-updates
-  specs:
-    guides_style_18f (0.5.0)
-      jekyll
-      jekyll_pages_api
-      jekyll_pages_api_search
-      rouge
-      sass
-
 GEM
   remote: https://rubygems.org/
   specs:
     colorator (0.1)
     ffi (1.9.18)
+    guides_style_18f (1.0.0)
+      jekyll
+      jekyll_pages_api
+      jekyll_pages_api_search
+      rouge
+      sass
     htmlentities (4.3.4)
     jekyll (3.1.6)
       colorator (~> 0.1)
@@ -52,7 +46,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  guides_style_18f!
+  guides_style_18f
   jekyll (~> 3.1.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,83 +1,59 @@
+GIT
+  remote: https://github.com/18F/guides-style.git
+  revision: a3a350d3a73f964b11f9b87803ab7ff77087ee87
+  branch: pages-migration-updates
+  specs:
+    guides_style_18f (0.5.0)
+      jekyll
+      jekyll_pages_api
+      jekyll_pages_api_search
+      rouge
+      sass
+
 GEM
   remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
-    classifier-reborn (2.0.3)
-      fast-stemmer (~> 1.0)
-    coffee-script (2.3.0)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.9.1)
     colorator (0.1)
-    execjs (2.4.0)
-    fast-stemmer (1.0.2)
-    ffi (1.9.8)
-    go_script (0.1.4)
-      bundler (~> 1.10)
-      safe_yaml (~> 1.0)
-    guides_style_18f (0.1.0)
-      jekyll (~> 2.5)
-      rouge (~> 1.9)
-      sass (~> 3.4)
-    hitimes (1.2.2)
-    jekyll (2.5.3)
-      classifier-reborn (~> 2.0)
+    ffi (1.9.18)
+    htmlentities (4.3.4)
+    jekyll (3.1.6)
       colorator (~> 0.1)
-      jekyll-coffeescript (~> 1.0)
-      jekyll-gist (~> 1.0)
-      jekyll-paginate (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 2.6.1)
+      liquid (~> 3.0)
       mercenary (~> 0.3.3)
-      pygments.rb (~> 0.6.0)
-      redcarpet (~> 3.1)
+      rouge (~> 1.7)
       safe_yaml (~> 1.0)
-      toml (~> 0.1.0)
-    jekyll-coffeescript (1.0.1)
-      coffee-script (~> 2.2)
-    jekyll-gist (1.2.1)
-    jekyll-paginate (1.1.0)
-    jekyll-sass-converter (1.3.0)
-      sass (~> 3.2)
-    jekyll-watch (1.2.1)
-      listen (~> 2.7)
-    kramdown (1.6.0)
-    liquid (2.6.2)
-    listen (2.10.0)
-      celluloid (~> 0.16.0)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    mercenary (0.3.5)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
-    posix-spawn (0.3.10)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
-    rb-fsevent (0.9.4)
-    rb-inotify (0.9.5)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    jekyll_pages_api (0.1.6)
+      htmlentities (~> 4.3)
+      jekyll (>= 2.0, < 4.0)
+    jekyll_pages_api_search (0.4.4)
+      jekyll_pages_api (~> 0.1.4)
+      sass (~> 3.4)
+    kramdown (1.13.2)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
-    redcarpet (3.2.2)
-    rouge (1.9.1)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.13)
-    timers (4.0.1)
-      hitimes
-    toml (0.1.2)
-      parslet (~> 1.5.0)
-    yajl-ruby (1.2.1)
+    sass (3.4.23)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  go_script
-  guides_style_18f
-  jekyll
+  guides_style_18f!
+  jekyll (~> 3.1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/_config.yml
+++ b/_config.yml
@@ -9,13 +9,13 @@ url: "http://pages.18f.gov/testing-cookbook/"
 github_username:  shawnbot
 
 # Build settings
-markdown: redcarpet
 exclude:
 - CONTRIBUTING.md
 - Gemfile
 - Gemfile.lock
 - LICENSE.md
 - README.md
+- '**/README.md'
 - go
 
 permalink: pretty

--- a/_config.yml
+++ b/_config.yml
@@ -6,16 +6,12 @@ description: >
   and manual testing in lots of different environments, languages, stacks and
   platforms.
 url: "http://pages.18f.gov/testing-cookbook/"
-github_username:  shawnbot
+github_username: 18F
 
 # Build settings
 exclude:
-- CONTRIBUTING.md
 - Gemfile
 - Gemfile.lock
-- LICENSE.md
-- README.md
-- '**/README.md'
 - go
 
 permalink: pretty
@@ -91,9 +87,6 @@ repos:
 - name: 18F Testing Cookbook
   description: Main repository
   url: https://github.com/18F/testing-cookbook
-
-# Style Variables
-brand_color: "#1188ff"
 
 google_analytics_ua: UA-48605964-19
 


### PR DESCRIPTION
#### [:eyes: Preview on Federalist](https://federalist.fr.cloud.gov/preview/18f/testing-cookbook/federalist/)

This is the start of migrating to Federalist, as described in [this doc](https://docs.google.com/document/d/1ZQDKPZbmUkoVtSrY61GUuBbDukauDo9brCQPvS5lObg/edit) (GSA only). Subtasks:

- [x] Reference the WIP update of `guides-style` in [this branch](https://github.com/18F/guides-style/pull/82)
- [x] Remove `markdown: redcarpet` from the Jekyll config because we don't need it
- [ ] ~Exclude all `README.md` files~ (this was breaking a lot of pages)
- [x] Update the `Gemfile` to point at the right `guides-style` gem once 18F/guides-style#82 is merged, and after any other (critical) future updates

cc @hbillings 